### PR TITLE
Add help argument for commands & options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ Options:
 ```
 Usage: shodo download [OPTIONS]
 
+  Download all of Markdown posts and images.
+
 Options:
-  --target TEXT      Target directory to save files
-  --in-tree BOOLEAN  Download only files with task Folder
-  --help             Show this message and exit.
+  --target DIRECTORY  Target directory to save files.
+  --in-tree           Download only files with task Folder.
+  --help              Show this message and exit.
 ```

--- a/shodo/main.py
+++ b/shodo/main.py
@@ -14,21 +14,29 @@ from shodo.lint import Lint
 
 
 @click.group()
-def cli():
-    ...
+def cli(): ...
 
 
-@cli.command()
+@cli.command(help="Login to Shodo API.")
 def login():
     root = input("APIルート: ")
     token = getpass("APIトークン:")
     save_credentials(root, token)
 
 
-@cli.command()
-@click.argument("filename", required=False)
-@click.option("--html", default=False, is_flag=True)
-@click.option("--output", default=None)
+@cli.command(help="Lint Japanese text.")
+@click.argument(
+    "filename", required=False, type=click.Path(exists=True, dir_okay=False)
+)
+@click.option(
+    "--html", help="Specify if the input is HTML.", default=False, is_flag=True
+)
+@click.option(
+    "--output",
+    help="Output format.",
+    default="text",
+    type=click.Choice(["text", "json"]),
+)
 def lint(filename, html, output):
     if filename is None:
         contents = []
@@ -79,9 +87,19 @@ def lint(filename, html, output):
         sys.exit(1)
 
 
-@cli.command()
-@click.option("--target", help="Target directory to save files", default="docs")
-@click.option("--in-tree", help="Download only files with task Folder", default=False)
+@cli.command(help="Download all of Markdown posts and images.")
+@click.option(
+    "--target",
+    help="Target directory to save files.",
+    default="docs",
+    type=click.Path(file_okay=False, writable=True),
+)
+@click.option(
+    "--in-tree",
+    help="Download only files with task Folder.",
+    default=False,
+    is_flag=True,
+)
 def download(target, in_tree):
     base_dir = Path() / target
     for file in list_post_files(in_tree=in_tree):


### PR DESCRIPTION
## `shodo --help`

```bash
Usage: shodo [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  download  Download all of Markdown posts and images.
  lint      Lint Japanese text.
  login     Login to Shodo API.
```

## `shodo download --help`

```bash
Usage: shodo download [OPTIONS]

  Download all of Markdown posts and images.

Options:
  --target DIRECTORY  Target directory to save files.
  --in-tree           Download only files with task Folder.
  --help              Show this message and exit.
```

### Invalid value for `target` option

1. File specified

```bash
$ shodo download --target demo/demo.md
Usage: shodo download [OPTIONS]
Try 'shodo download --help' for help.

Error: Invalid value for '--target': Directory 'demo/demo.md' is a file.
```

2. Specified directory is not writable

```bash
$ shodo download --target docs
Usage: shodo download [OPTIONS]
Try 'shodo download --help' for help.

Error: Invalid value for '--target': Directory 'docs' is not writable.
```

## `shodo lint --help`

```bash
Usage: shodo lint [OPTIONS] [FILENAME]

  Lint Japanese text.

Options:
  --html                Specify if the input is HTML.
  --output [text|json]  Output format.
  --help                Show this message and exit.
```

### Invalid for `FILENAME` argument

1. Dose not exist file

```bash
$ shodo lint demo/demo.text
Usage: shodo lint [OPTIONS] [FILENAME]
Try 'shodo lint --help' for help.

Error: Invalid value for '[FILENAME]': File 'demo/demo.txt' does not exist.
```

2. Directory specified

```bash
$ shodo lint demo
Usage: shodo lint [OPTIONS] [FILENAME]
Try 'shodo lint --help' for help.

Error: Invalid value for '[FILENAME]': File 'demo' is a directory.
```

### Invalid value for `output` options

```bash
$ shodo lint demo/demo.md --output yaml
Usage: shodo lint [OPTIONS] [FILENAME]
Try 'shodo lint --help' for help.

Error: Invalid value for '--output': 'yaml' is not one of 'text', 'json'.
```

## `shodo login --help`

```bash
Usage: shodo login [OPTIONS]

  Login to Shodo API.

Options:
  --help  Show this message and exit.
```