### PR TITLE
Filter low score lint results message

### DIFF
--- a/shodo/main.py
+++ b/shodo/main.py
@@ -58,6 +58,8 @@ def lint(filename, html, output):
         return
 
     for message in linting.results():
+        if message.score < 0.5:
+            continue
         color = "red" if message.severity == message.ERROR else "yellow"
         body_highlight = (
             body[message.index - 10 : message.index]


### PR DESCRIPTION
If output is default, hide lint messages with score less than `0.5`.