### PR TITLE
プロファイル機能の追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.black]
+line-length = 99
+exclude = '''
+(
+    .mypy_cache
+    | .pytest_cache
+    | .tox
+    | venv
+    | .venv
+    | env
+)
+'''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+line_length = 99
+src_paths = 'shodo, tests'

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ setup(
         "Click",
         "requests",
     ],
+    extras_require={
+        "dev": [
+            "pytest",
+            "pytest-mock",
+        ],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "Development Status :: 3 - Alpha",

--- a/shodo/conf.py
+++ b/shodo/conf.py
@@ -42,7 +42,7 @@ def load_credentials(profile: Optional[str] = None):
         p = Path(OLD_CREDENTIALS_PATH).expanduser()
         if not p.exists():
             raise UnableLocateCredentialsError(
-                "Use 'shodo login' to save credentials before running"
+                "Use 'shodo login' to save credentials before running."
             )
 
     d = json.loads(p.read_text(encoding="utf-8"))
@@ -51,7 +51,7 @@ def load_credentials(profile: Optional[str] = None):
         msg = (
             f"The config profile ({profile}) could not be found."
             if profile is not None
-            else "Use 'shodo login' to save credentials before running"
+            else "Use 'shodo login' to save credentials before running."
         )
         raise UnableLocateCredentialsError(msg)
     return c

--- a/shodo/conf.py
+++ b/shodo/conf.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+from typing import Optional
 
 SHODO_TOKEN = "SHODO_API_TOKEN"
 SHODO_ROOT = "SHODO_API_ROOT"
@@ -13,7 +14,7 @@ def get_path():
     return config_path / "shodo/credentials"
 
 
-def save_credentials(root: str, token: str):
+def save_credentials(root: str, token: str, profile: str):
     c = get_path()
     if not c.parent.exists():
         c.parent.mkdir()
@@ -23,14 +24,14 @@ def save_credentials(root: str, token: str):
     else:
         d = {}
 
-    d["default"] = {
+    d[profile] = {
         SHODO_ROOT: root,
         SHODO_TOKEN: token,
     }
     c.write_text(json.dumps(d, indent=2), encoding="utf-8")
 
 
-def load_credentials():
+def load_credentials(profile: Optional[str] = None):
     p = get_path()
     if not p.exists():
         p = Path(OLD_CREDENTIALS_PATH).expanduser()
@@ -40,14 +41,14 @@ def load_credentials():
             )
 
     d = json.loads(p.read_text(encoding="utf-8"))
-    return d["default"]
+    return d[profile]
 
 
-def conf():
-    if SHODO_TOKEN in os.environ and SHODO_ROOT in os.environ:
+def conf(profile: Optional[str] = None):
+    if not profile and SHODO_TOKEN in os.environ and SHODO_ROOT in os.environ:
         c = os.environ
     else:
-        c = load_credentials()
+        c = load_credentials(profile)
     return {
         "API_ROOT": c[SHODO_ROOT],
         "API_TOKEN": c[SHODO_TOKEN],

--- a/shodo/lint.py
+++ b/shodo/lint.py
@@ -57,17 +57,18 @@ class Lint:
     STATUS_PROCESSING = "processing"
     STATUS_FAILED = "failed"
 
-    def __init__(self, body, lint_id):
+    def __init__(self, body, lint_id, profile):
         self.body = body
         self.lint_id = lint_id
         self.body = None
         self.status = self.STATUS_PROCESSING
         self.messages = []
+        self.profile = profile
 
     def results(self):
         while self.status == self.STATUS_PROCESSING:
             time.sleep(0.5)
-            self.status, messages = lint_result(self.lint_id)
+            self.status, messages = lint_result(self.lint_id, self.profile)
             msgs = [Message.load(m) for m in messages]
             self.messages = sorted(msgs, key=lambda m: (m.from_.line, m.from_.ch))
 
@@ -80,6 +81,6 @@ class Lint:
         return f"Lint({self.lint_id})"
 
     @classmethod
-    def start(cls, body, is_html=False):
-        lint_id = lint_create(body, is_html)
-        return cls(body, lint_id)
+    def start(cls, body: str, is_html: bool = False, profile: Optional[str] = None):
+        lint_id = lint_create(body, is_html, profile)
+        return cls(body, lint_id, profile)

--- a/shodo/main.py
+++ b/shodo/main.py
@@ -19,17 +19,27 @@ def cli():
 
 
 @cli.command()
-def login():
+@click.option(
+    "--profile",
+    help="Save a specific profile to your credential file.",
+    default="default",
+)
+def login(profile):
     root = input("APIルート: ")
     token = getpass("APIトークン:")
-    save_credentials(root, token)
+    save_credentials(root, token, profile)
 
 
 @cli.command()
 @click.argument("filename", required=False)
 @click.option("--html", default=False, is_flag=True)
 @click.option("--output", default=None)
-def lint(filename, html, output):
+@click.option(
+    "--profile",
+    help="Use a specific profile from your credential file.",
+    default="default",
+)
+def lint(filename, html, output, profile):
     if filename is None:
         contents = []
         while True:
@@ -44,7 +54,7 @@ def lint(filename, html, output):
     if not body:
         return
 
-    linting = Lint.start(body, is_html=html)
+    linting = Lint.start(body, is_html=html, profile=profile)
     print("Linting...")
 
     if output == "json":
@@ -82,9 +92,14 @@ def lint(filename, html, output):
 @cli.command()
 @click.option("--target", help="Target directory to save files", default="docs")
 @click.option("--in-tree", help="Download only files with task Folder", default=False)
-def download(target, in_tree):
+@click.option(
+    "--profile",
+    help="Use a specific profile from your credential file.",
+    default="default",
+)
+def download(target, in_tree, profile):
     base_dir = Path() / target
-    for file in list_post_files(in_tree=in_tree):
+    for file in list_post_files(in_tree=in_tree, profile=profile):
         dir_path = base_dir / (file["directory_path"] or "未分類")
         dir_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -42,7 +42,7 @@ class TestLoadCredentials:
         with pytest.raises(UnableLocateCredentialsError) as e:
             load_credentials(profile)
 
-        assert e.value.msg == "Use 'shodo login' to save credentials before running"
+        assert e.value.msg == "Use 'shodo login' to save credentials before running."
 
     @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
     def test_exist_credentials(self, credentials_path, api_root, profile):
@@ -58,7 +58,7 @@ class TestLoadCredentials:
     @pytest.mark.parametrize(
         "profile, expected",
         [
-            (None, "Use 'shodo login' to save credentials before running"),
+            (None, "Use 'shodo login' to save credentials before running."),
             ("default", "The config profile (default) could not be found."),
             ("tests", "The config profile (tests) could not be found."),
         ],
@@ -86,7 +86,7 @@ class TestConf:
         with pytest.raises(UnableLocateCredentialsError) as e:
             conf(None)
 
-        assert e.value.msg == "Use 'shodo login' to save credentials before running"
+        assert e.value.msg == "Use 'shodo login' to save credentials before running."
 
     def test_profile_is_none(self, credentials_path, shodo_envs, api_root):
         actual = conf(None)

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,118 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from shodo.conf import UnableLocateCredentialsError, conf, load_credentials, save_credentials
+
+
+@pytest.fixture
+def credentials_path(tmp_path) -> Path:
+    os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
+    yield tmp_path / "shodo" / "credentials"
+    del os.environ["XDG_CONFIG_HOME"]
+
+
+@pytest.fixture
+def api_root() -> str:
+    return "https://api.shodo.ink/@my-organization/"
+
+
+@pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+def test_save_credentials(credentials_path, api_root, profile):
+    save_credentials(f"{api_root}{profile}/", "stub-token", profile)
+
+    creds = json.loads(credentials_path.read_text())
+    actual = creds[profile]
+
+    assert actual == {
+        "SHODO_API_ROOT": f"{api_root}{profile}/",
+        "SHODO_API_TOKEN": "stub-token",
+    }
+
+
+class TestLoadCredentials:
+    @pytest.mark.parametrize(
+        "profile",
+        [None, "default", "tests"],
+        ids=["None", "default", "tests"],
+    )
+    def test_no_exist_credentials_file(self, credentials_path, profile):
+        with pytest.raises(UnableLocateCredentialsError) as e:
+            load_credentials(profile)
+
+        assert e.value.msg == "Use 'shodo login' to save credentials before running"
+
+    @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+    def test_exist_credentials(self, credentials_path, api_root, profile):
+        save_credentials(f"{api_root}{profile}/", "stub-token", profile)
+
+        actual = load_credentials(profile)
+
+        assert actual == {
+            "SHODO_API_ROOT": f"{api_root}{profile}/",
+            "SHODO_API_TOKEN": "stub-token",
+        }
+
+    @pytest.mark.parametrize(
+        "profile, expected",
+        [
+            (None, "Use 'shodo login' to save credentials before running"),
+            ("default", "The config profile (default) could not be found."),
+            ("tests", "The config profile (tests) could not be found."),
+        ],
+        ids=["None", "default", "tests"],
+    )
+    def test_not_found_profile(self, credentials_path, api_root, profile, expected):
+        save_credentials(f"{api_root}{profile}/", "stub-token", "dummy")
+
+        with pytest.raises(UnableLocateCredentialsError) as e:
+            load_credentials(profile)
+
+        assert e.value.msg == expected
+
+
+class TestConf:
+    @pytest.fixture
+    def shodo_envs(self, api_root):
+        os.environ["SHODO_API_ROOT"] = f"{api_root}default/"
+        os.environ["SHODO_API_TOKEN"] = "stub-token"
+        yield
+        del os.environ["SHODO_API_ROOT"]
+        del os.environ["SHODO_API_TOKEN"]
+
+    def test_profile_and_envs_is_none(self, credentials_path):
+        with pytest.raises(UnableLocateCredentialsError) as e:
+            conf(None)
+
+        assert e.value.msg == "Use 'shodo login' to save credentials before running"
+
+    def test_profile_is_none(self, credentials_path, shodo_envs, api_root):
+        actual = conf(None)
+
+        assert actual == {
+            "API_ROOT": f"{api_root}default/",
+            "API_TOKEN": "stub-token",
+        }
+
+    @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+    def test_envs_is_none(self, credentials_path, api_root, profile):
+        save_credentials(f"{api_root}{profile}/", "stub-token", profile)
+
+        actual = conf(profile)
+
+        assert actual == {
+            "API_ROOT": f"{api_root}{profile}/",
+            "API_TOKEN": "stub-token",
+        }
+
+    def test_profile_and_envs_is_not_none(self, credentials_path, shodo_envs, api_root):
+        save_credentials(f"{api_root}default/", "stub-token", "default")
+
+        actual = conf("default")
+
+        assert actual == {
+            "API_ROOT": f"{api_root}default/",
+            "API_TOKEN": "stub-token",
+        }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,223 @@
+import uuid
+from os import access
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from shodo.conf import UnableLocateCredentialsError
+from shodo.lint import Lint, Message
+from shodo.main import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def filename() -> Path:
+    return Path(__file__).parent.parent / "demo" / "demo.md"
+
+
+class TestLogin:
+    def test_no_profile(self, mocker, runner):
+        mocker.patch(
+            "builtins.input",
+            return_value="https://api.shodo.ink/@my-organization/my-project/",
+        )
+        mocker.patch("shodo.main.getpass", return_value="stub-token")
+        m_save_credentials = mocker.patch("shodo.main.save_credentials")
+
+        actual = runner.invoke(cli, ["login"])
+
+        assert actual.exit_code == 0
+        assert m_save_credentials.call_count == 1
+        assert m_save_credentials.call_args == (
+            (
+                "https://api.shodo.ink/@my-organization/my-project/",
+                "stub-token",
+                "default",
+            ),
+        )
+
+    @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+    def test_with_profile(self, mocker, runner, profile):
+        mocker.patch(
+            "builtins.input",
+            return_value=f"https://api.shodo.ink/@my-organization/{profile}/",
+        )
+        mocker.patch("shodo.main.getpass", return_value="stub-token")
+        m_save_credentials = mocker.patch("shodo.main.save_credentials")
+
+        actual = runner.invoke(cli, ["login", "--profile", profile])
+
+        assert actual.exit_code == 0
+        assert m_save_credentials.call_count == 1
+        assert m_save_credentials.call_args == (
+            (
+                f"https://api.shodo.ink/@my-organization/{profile}/",
+                "stub-token",
+                profile,
+            ),
+        )
+
+
+class TestLint:
+    def test_no_profile(self, mocker, runner, filename):
+        body = filename.read_text(encoding="utf-8")
+        linting = Lint(body, str(uuid.uuid4()), None)
+        m_lint = mocker.patch("shodo.main.Lint.start", return_value=linting)
+        stub_results = [
+            Message.load(data)
+            for data in [
+                {
+                    "code": "variants:fuzzy",
+                    "message": "表記ゆれがあります",
+                    "severity": "error",
+                    "to": {
+                        "line": 0,
+                        "ch": 12,
+                    },
+                    "index": 2,
+                    "index_to": 12,
+                    "score": 0.8888888888888888,
+                    "before": "Shodo AI校正",
+                    "after": "Shodo AI校正",
+                    "operation": "replace",
+                    "meta": {
+                        "description": "",
+                    },
+                    "from": {
+                        "line": 0,
+                        "ch": 2,
+                    },
+                },
+            ]
+        ]
+        mocker.patch.object(Lint, "results", return_value=stub_results)
+
+        actual = runner.invoke(cli, ["lint", str(filename)])
+
+        assert actual.exit_code == 0
+        assert (
+            actual.output
+            == "Linting...\n1:3 表記ゆれがあります\n     \x1b[31mShodo AI校正（→ Shodo AI校正）\x1b[0m  飛行機の欠便があ\n"
+        )
+        assert m_lint.call_count == 1
+        assert m_lint.call_args == ((body,), {"is_html": False, "profile": None})
+
+    @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+    def test_with_profile(self, mocker, runner, filename, profile):
+        body = filename.read_text(encoding="utf-8")
+        linting = Lint(body, str(uuid.uuid4()), profile)
+        m_lint = mocker.patch("shodo.main.Lint.start", return_value=linting)
+        mocker.patch.object(Lint, "results", return_value=[])
+
+        actual = runner.invoke(cli, ["lint", str(filename), "--profile", profile])
+
+        assert actual.exit_code == 0
+        assert actual.output == "Linting...\n"
+        assert m_lint.call_count == 1
+        assert m_lint.call_args == ((body,), {"is_html": False, "profile": profile})
+
+    def test_no_existing_default_profile(self, mocker, filename, runner):
+        body = filename.read_text(encoding="utf-8")
+        m_lint = mocker.patch(
+            "shodo.main.Lint.start",
+            side_effect=UnableLocateCredentialsError(
+                "Use 'shodo login' to save credentials before running"
+            ),
+        )
+
+        actual = runner.invoke(cli, ["lint", str(filename)])
+
+        assert actual.exit_code == 1
+        assert actual.exception.msg == "Use 'shodo login' to save credentials before running"
+        assert m_lint.call_count == 1
+        assert m_lint.call_args == ((body,), {"is_html": False, "profile": None})
+
+    def test_not_found_profile(self, mocker, filename, runner):
+        body = filename.read_text(encoding="utf-8")
+        m_lint = mocker.patch(
+            "shodo.main.Lint.start",
+            side_effect=UnableLocateCredentialsError(
+                "The config profile (tests) could not be found."
+            ),
+        )
+
+        actual = runner.invoke(cli, ["lint", str(filename), "--profile", "tests"])
+
+        assert actual.exit_code == 1
+        assert actual.exception.msg == "The config profile (tests) could not be found."
+        assert m_lint.call_count == 1
+        assert m_lint.call_args == ((body,), {"is_html": False, "profile": "tests"})
+
+
+class TestDownload:
+    def test_no_profile(self, tmp_path, mocker, filename, runner):
+        stub_files = [
+            {
+                "number": 1,
+                "directory_path": None,
+                "filename": "Shodo_AI校正.md",
+                "body": filename.read_text(encoding="utf-8"),
+                "version": 3,
+                "committed_at": "2024-11-05T15:05:10.838949+09:00",
+                "images": [],
+                "task": {},  # not used
+            }
+        ]
+        m_lint_post_files = mocker.patch("shodo.main.list_post_files", return_value=stub_files)
+
+        actual = runner.invoke(cli, ["download", "--target", str(tmp_path)])
+
+        assert actual.exit_code == 0
+        assert actual.output == f"Downloaded {tmp_path}/未分類/Shodo_AI校正.md\n"
+        assert m_lint_post_files.call_count == 1
+        assert m_lint_post_files.call_args == ((), {"in_tree": False, "profile": None})
+        directory_path = tmp_path / "未分類"
+        assert directory_path.exists()
+        md_path = directory_path / "Shodo_AI校正.md"
+        assert md_path.exists()
+
+    @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
+    def test_with_profile(self, tmp_path, mocker, runner, profile):
+        m_lint_post_files = mocker.patch("shodo.main.list_post_files", return_value=[])
+
+        actual = runner.invoke(cli, ["download", "--target", str(tmp_path), "--profile", profile])
+
+        assert actual.exit_code == 0
+        assert actual.output == ""
+        assert m_lint_post_files.call_count == 1
+        assert m_lint_post_files.call_args == ((), {"in_tree": False, "profile": profile})
+
+    def test_no_existing_default_profile(self, tmp_path, mocker, runner):
+        m_lint_post_files = mocker.patch(
+            "shodo.main.list_post_files",
+            side_effect=UnableLocateCredentialsError(
+                "Use 'shodo login' to save credentials before running"
+            ),
+        )
+
+        actual = runner.invoke(cli, ["download", "--target", str(tmp_path)])
+
+        assert actual.exit_code == 1
+        assert actual.exception.msg == "Use 'shodo login' to save credentials before running"
+        assert m_lint_post_files.call_count == 1
+        assert m_lint_post_files.call_args == ((), {"in_tree": False, "profile": None})
+
+    def test_not_found_profile(self, tmp_path, mocker, runner):
+        m_lint_post_files = mocker.patch(
+            "shodo.main.list_post_files",
+            side_effect=UnableLocateCredentialsError(
+                "The config profile (tests) could not be found."
+            ),
+        )
+
+        actual = runner.invoke(cli, ["download", "--target", str(tmp_path), "--profile", "tests"])
+
+        assert actual.exit_code == 1
+        assert actual.exception.msg == "The config profile (tests) could not be found."
+        assert m_lint_post_files.call_count == 1
+        assert m_lint_post_files.call_args == ((), {"in_tree": False, "profile": "tests"})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,14 +126,14 @@ class TestLint:
         m_lint = mocker.patch(
             "shodo.main.Lint.start",
             side_effect=UnableLocateCredentialsError(
-                "Use 'shodo login' to save credentials before running"
+                "Use 'shodo login' to save credentials before running."
             ),
         )
 
         actual = runner.invoke(cli, ["lint", str(filename)])
 
         assert actual.exit_code == 1
-        assert actual.exception.msg == "Use 'shodo login' to save credentials before running"
+        assert actual.exception.msg == "Use 'shodo login' to save credentials before running."
         assert m_lint.call_count == 1
         assert m_lint.call_args == ((body,), {"is_html": False, "profile": None})
 
@@ -196,14 +196,14 @@ class TestDownload:
         m_lint_post_files = mocker.patch(
             "shodo.main.list_post_files",
             side_effect=UnableLocateCredentialsError(
-                "Use 'shodo login' to save credentials before running"
+                "Use 'shodo login' to save credentials before running."
             ),
         )
 
         actual = runner.invoke(cli, ["download", "--target", str(tmp_path)])
 
         assert actual.exit_code == 1
-        assert actual.exception.msg == "Use 'shodo login' to save credentials before running"
+        assert actual.exception.msg == "Use 'shodo login' to save credentials before running."
         assert m_lint_post_files.call_count == 1
         assert m_lint_post_files.call_args == ((), {"in_tree": False, "profile": None})
 


### PR DESCRIPTION
## プロファイル機能

各サブコマンドに `--profile` オプションを追加。ない場合は `login` の場合は `default` とし他のサブコマンドでは `None` が設定される。

```bash
$ shodo login --profile lint-api
$ shodo lint demo/demo.md --profile lint-api
$ shodo download --profile lint-api
```

## credentials エラー

`--profile` に設定されたプロファイルが設定されていない場合は以下のエラーが発生する。 `lint-api` プロファイルを入力したものとする。

```bash
$ shodo lint demo/demo.md --profile lint-api
The config profile (lint-api) could not be found.
```

また、 `default` は明示的に指定したときは上記と同じエラーが発生するが、認証情報なしでオプション指定をせずに `lint` 、 `download` を行った場合は以下のエラーが発生する。

```bash
$ shodo lint demo/demo.md
Use 'shodo login' to save credentials before running.
```