### PR TITLE
プロファイル指定がない場合の認証情報読み込みの修正

### DIFF
--- a/shodo/conf.py
+++ b/shodo/conf.py
@@ -46,7 +46,7 @@ def load_credentials(profile: Optional[str] = None):
             )
 
     d = json.loads(p.read_text(encoding="utf-8"))
-    c = d.get(profile)
+    c = d.get(profile or "default")
     if c is None:
         msg = (
             f"The config profile ({profile}) could not be found."

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -44,8 +44,18 @@ class TestLoadCredentials:
 
         assert e.value.msg == "Use 'shodo login' to save credentials before running."
 
+    def test_exist_credentials_without_profile(self, credentials_path, api_root):
+        save_credentials(f"{api_root}default/", "stub-token", "default")
+
+        actual = load_credentials(None)
+
+        assert actual == {
+            "SHODO_API_ROOT": f"{api_root}default/",
+            "SHODO_API_TOKEN": "stub-token",
+        }
+
     @pytest.mark.parametrize("profile", ["default", "tests"], ids=["default", "tests"])
-    def test_exist_credentials(self, credentials_path, api_root, profile):
+    def test_exist_credentials_with_profile(self, credentials_path, api_root, profile):
         save_credentials(f"{api_root}{profile}/", "stub-token", profile)
 
         actual = load_credentials(profile)


### PR DESCRIPTION
default の認証情報が保存されている場合でも `--profile` が実装都合で必須になっていたので修正

## After

```bash
$ shodo lint demo/demo.md
Linting...
(省略)
```

## Before

```bash
$ shodo lint demo/demo.md
Use 'shodo login' to save credentials before running.

$ shodo lint demo/demo.md --profile default
Linting...
(省略)
```