### PR TITLE
click.echo で出力を行うようにする

### DIFF
--- a/shodo/main.py
+++ b/shodo/main.py
@@ -73,10 +73,10 @@ def lint(filename, html, output, profile):
         return
 
     linting = Lint.start(body, is_html=html, profile=profile)
-    print("Linting...")
+    click.echo("Linting...", err=True)
 
     if output == "json":
-        print(
+        click.echo(
             json.dumps(
                 [msg.asdict() for msg in linting.results()],
                 ensure_ascii=False,
@@ -102,8 +102,12 @@ def lint(filename, html, output, profile):
             )
             + body[message.index_to : message.index_to + 10]
         ).replace("\n", " ")
-        print(message.from_, message.message)
-        print("    ", body_highlight)
+
+        click.echo(message.from_, nl=False)
+        click.echo(" ", nl=False)
+        click.echo(message.message)
+        click.echo("     ", nl=False)
+        click.echo(body_highlight)
 
     if linting.messages:
         sys.exit(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,4 @@
 import uuid
-from os import access
 from pathlib import Path
 
 import pytest
@@ -97,7 +96,7 @@ class TestLint:
         ]
         mocker.patch.object(Lint, "results", return_value=stub_results)
 
-        actual = runner.invoke(cli, ["lint", str(filename)])
+        actual = runner.invoke(cli, args=["lint", str(filename)], color=True)
 
         assert actual.exit_code == 0
         assert (


### PR DESCRIPTION
print にて行っていた標準出力を `click.echo` で行う
また、 `Linting...` は標準エラーに逃がして、 `shodo lint demo/demo.md --output json | jq` などで `Linting...` に邪魔されずにパイプを繋げられるようにします。