### PR TITLE
古い内部用クラスの削除

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,11 @@ setup(
             "aiohttp",
         ],
         "dev": [
+            "aioresponses",
             "pytest",
+            "pytest-asyncio",
             "pytest-mock",
+            "pytest-responses",
             "mypy",
             "types-requests",
         ],

--- a/shodo/aio/lint.py
+++ b/shodo/aio/lint.py
@@ -7,13 +7,13 @@ from shodo.aio.api import lint_create, lint_result
 from shodo.lint import LintFailed, LintResult, LintStatus, Message
 
 
-async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> LintResult:
+async def lint(body: str, is_html: bool = False, profile: Optional[str] = None, _initial_pause: float = 0.25) -> LintResult:
     async with aiohttp.ClientSession() as session:
         create_res = await lint_create(body, is_html, profile, session)
 
         status = LintStatus.PROCESSING.value
-        pause = 0.25
-        while status == LintStatus.PROCESSING:
+        pause = _initial_pause
+        while status == LintStatus.PROCESSING.value:
             await asyncio.sleep(pause)
             result_res = await lint_result(create_res.lint_id, profile, session)
             status = result_res.status
@@ -23,7 +23,7 @@ async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) 
             if pause < 16:
                 pause *= 2
 
-        if status == LintStatus.FAILED:
+        if status == LintStatus.FAILED.value:
             raise LintFailed
 
         return LintResult(status=status, messages=messages, updated=result_res.updated)

--- a/shodo/aio/lint.py
+++ b/shodo/aio/lint.py
@@ -4,16 +4,16 @@ from typing import Optional
 import aiohttp
 
 from shodo.aio.api import lint_create, lint_result
-from shodo.lint import Lint, LintFailed, LintResult, Message
+from shodo.lint import LintFailed, LintResult, LintStatus, Message
 
 
 async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> LintResult:
     async with aiohttp.ClientSession() as session:
         create_res = await lint_create(body, is_html, profile, session)
 
-        status = Lint.STATUS_PROCESSING.value
+        status = LintStatus.PROCESSING.value
         pause = 0.25
-        while status == Lint.STATUS_PROCESSING.value:
+        while status == LintStatus.PROCESSING:
             await asyncio.sleep(pause)
             result_res = await lint_result(create_res.lint_id, profile, session)
             status = result_res.status
@@ -23,7 +23,7 @@ async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) 
             if pause < 16:
                 pause *= 2
 
-        if status == Lint.STATUS_FAILED.value:
+        if status == LintStatus.FAILED:
             raise LintFailed
 
         return LintResult(status=status, messages=messages, updated=result_res.updated)

--- a/shodo/aio/lint.py
+++ b/shodo/aio/lint.py
@@ -11,9 +11,9 @@ async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) 
     async with aiohttp.ClientSession() as session:
         create_res = await lint_create(body, is_html, profile, session)
 
-        status = Lint.STATUS_PROCESSING
+        status = Lint.STATUS_PROCESSING.value
         pause = 0.25
-        while status == Lint.STATUS_PROCESSING:
+        while status == Lint.STATUS_PROCESSING.value:
             await asyncio.sleep(pause)
             result_res = await lint_result(create_res.lint_id, profile, session)
             status = result_res.status
@@ -23,7 +23,7 @@ async def lint(body: str, is_html: bool = False, profile: Optional[str] = None) 
             if pause < 16:
                 pause *= 2
 
-        if status == Lint.STATUS_FAILED:
+        if status == Lint.STATUS_FAILED.value:
             raise LintFailed
 
         return LintResult(status=status, messages=messages, updated=result_res.updated)

--- a/shodo/api.py
+++ b/shodo/api.py
@@ -1,12 +1,19 @@
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional
 
 import requests
 
 from shodo.conf import conf
+
+try:
+    from zoneinfo import ZoneInfo
+    JST = ZoneInfo("Asia/Tokyo")
+except ImportError:
+    from datetime import timedelta, timezone
+    JST = timezone(timedelta(hours=+9), "JST")
 
 
 def api_path(path, profile) -> str:
@@ -37,7 +44,7 @@ class LintResultResponse:
 
     def __post_init__(self) -> None:
         if isinstance(self.updated, int):
-            self.updated = datetime.fromtimestamp(self.updated)
+            self.updated = datetime.fromtimestamp(self.updated, JST)
 
 
 def lint_create(

--- a/shodo/lint.py
+++ b/shodo/lint.py
@@ -1,7 +1,7 @@
 import time
-from enum import Enum
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from shodo.api import lint_create, lint_result
@@ -71,12 +71,12 @@ class LintStatus(Enum):
     DONE = "done"
 
 
-def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> LintResult:
+def lint(body: str, is_html: bool = False, profile: Optional[str] = None, _initial_pause: float=0.25) -> LintResult:
     create_res = lint_create(body, is_html, profile)
 
     status = LintStatus.PROCESSING.value
-    pause = 0.25
-    while status == LintStatus.PROCESSING:
+    pause = _initial_pause
+    while status == LintStatus.PROCESSING.value:
         time.sleep(pause)
         result_res = lint_result(create_res.lint_id, profile)
         status = result_res.status
@@ -86,7 +86,7 @@ def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> Lin
         if pause < 16:
             pause *= 2
 
-    if status == LintStatus.FAILED:
+    if status == LintStatus.FAILED.value:
         raise LintFailed
 
     return LintResult(status=status, messages=messages, updated=result_res.updated)

--- a/shodo/lint.py
+++ b/shodo/lint.py
@@ -65,17 +65,18 @@ class LintFailed(Exception):
     pass
 
 
-class Lint(Enum):
-    STATUS_PROCESSING = "processing"
-    STATUS_FAILED = "failed"
+class LintStatus(Enum):
+    PROCESSING = "processing"
+    FAILED = "failed"
+    DONE = "done"
 
 
 def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> LintResult:
     create_res = lint_create(body, is_html, profile)
 
-    status = Lint.STATUS_PROCESSING.value
+    status = LintStatus.PROCESSING.value
     pause = 0.25
-    while status == Lint.STATUS_PROCESSING.value:
+    while status == LintStatus.PROCESSING:
         time.sleep(pause)
         result_res = lint_result(create_res.lint_id, profile)
         status = result_res.status
@@ -85,7 +86,7 @@ def lint(body: str, is_html: bool = False, profile: Optional[str] = None) -> Lin
         if pause < 16:
             pause *= 2
 
-    if status == Lint.STATUS_FAILED.value:
+    if status == LintStatus.FAILED:
         raise LintFailed
 
     return LintResult(status=status, messages=messages, updated=result_res.updated)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def credential(monkeypatch):
+    monkeypatch.setenv("SHODO_API_ROOT", "https://api.shodo.ink/@shodo/shodo/")
+    monkeypatch.setenv("SHODO_API_TOKEN", "test-token")

--- a/tests/test_aio/test_lint.py
+++ b/tests/test_aio/test_lint.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from aioresponses import aioresponses
 
 import pytest
@@ -26,7 +26,7 @@ async def test_lint(credential):
 
         assert actual.status == "done"
         assert actual.messages == []
-        assert actual.updated == datetime(2023, 11, 15, 7, 13, 20)
+        assert actual.updated.timetuple()[:6] == (2023, 11, 15, 7, 13, 20)
         m.assert_called_with(
             "https://api.shodo.ink/@shodo/shodo/lint/",
             "post",

--- a/tests/test_aio/test_lint.py
+++ b/tests/test_aio/test_lint.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from aioresponses import aioresponses
+
+import pytest
+from shodo.aio.lint import lint
+
+
+@pytest.mark.asyncio
+async def test_lint(credential):
+    with aioresponses() as m:
+        m.post(
+            "https://api.shodo.ink/@shodo/shodo/lint/",
+            payload={
+                "lint_id": "spam-spam-spam",
+                "monthly_amount": 100,
+                "current_usage": 10,
+                "len_body": 10,
+                "len_used": 10,
+            },
+        )
+        m.get(
+            "https://api.shodo.ink/@shodo/shodo/lint/spam-spam-spam/",
+            payload={"status": "done", "updated": 1_700_000_000, "messages": []},
+        )
+        actual = await lint("body", is_html=False)
+
+        assert actual.status == "done"
+        assert actual.messages == []
+        assert actual.updated == datetime(2023, 11, 15, 7, 13, 20)
+        m.assert_called_with(
+            "https://api.shodo.ink/@shodo/shodo/lint/",
+            "post",
+            json={
+                "body": "body",
+                "type": "text",
+            },
+            headers={"Authorization": "Bearer test-token"},
+        )
+        m.assert_called_with(
+            "https://api.shodo.ink/@shodo/shodo/lint/spam-spam-spam/",
+            "get",
+            headers={"Authorization": "Bearer test-token"},
+        )

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from shodo.lint import lint
 
@@ -31,7 +31,7 @@ class TestLint:
 
         assert actual.status == "done"
         assert actual.messages == []
-        assert actual.updated == datetime(2023, 11, 15, 7, 13, 20)
+        assert actual.updated.timetuple()[:6] == (2023, 11, 15, 7, 13, 20)
 
         assert len(responses.calls) == 2
         assert json.loads(responses.calls[0].request.body.decode("utf-8")) == {

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,40 @@
+import json
+from datetime import datetime
+
+from shodo.lint import lint
+
+
+class TestLint:
+    def test_lint(self, credential, responses):
+        responses.add(
+            "POST",
+            "https://api.shodo.ink/@shodo/shodo/lint/",
+            json={
+                "lint_id": "spam-spam-spam",
+                "monthly_amount": 100,
+                "current_usage": 10,
+                "len_body": 10,
+                "len_used": 10,
+            },
+        )
+        responses.add(
+            "GET",
+            "https://api.shodo.ink/@shodo/shodo/lint/spam-spam-spam/",
+            json={
+                "status": "done",
+                "messages": [],
+                "updated": 1_700_000_000,
+            },
+        )
+
+        actual = lint("これはテストです", is_html=False, profile=None, _initial_pause=0)
+
+        assert actual.status == "done"
+        assert actual.messages == []
+        assert actual.updated == datetime(2023, 11, 15, 7, 13, 20)
+
+        assert len(responses.calls) == 2
+        assert json.loads(responses.calls[0].request.body.decode("utf-8")) == {
+            "body": "これはテストです",
+            "type": "text",
+        }


### PR DESCRIPTION
クラスで実装されていた古い `Lint` の削除です。
内部的にのみ使っていたクラスなので今後不要になります。モジュールとしてのAPIを考えると複数あると美しくないため、関数に統一します。使われるべき外部向けの関数としては、 `lint()` か `api.lint_create()` とします。
