### PR TITLE
CI でのテスト実行

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: setup.py
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/tests.yml
+    - shodo/**
+    - tests/**
+  pull_request:
+    paths:
+    - .github/workflows/tests.yml
+    - shodo/**
+    - tests/**
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+    name: Python ${{ matrix.python-version }} tests
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -e ".[dev]"
+
+    - name: Run tests
+      run: pytest tests/

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ README = open(os.path.join(here, "README.md")).read()
 setup(
     name="shodo",
     version="1.0.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     url="https://github.com/zenproducts/shodo-python",
     license="MIT",
     author="ZenProducts Inc.",
@@ -46,4 +46,5 @@ setup(
             "py.typed",
         ],
     },
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
Python 3.8 は EOL を迎えてるので切ってもいいかなと思ったんですが、 Click がまだ対応していたので一応サポート圏内にしておきます。